### PR TITLE
Revive the "Latest template version" column

### DIFF
--- a/app/views/templateList.scala.html
+++ b/app/views/templateList.scala.html
@@ -10,8 +10,9 @@
         <tr>
             <th class="text-center">Comm Name</th>
             <th class="text-center">Comm Type</th>
-            <th class="text-center">See Comm performance</th>
             <th class="text-center">Latest template version</th>
+            <th class="text-center">See Comm performance</th>
+            <th></th>
         </tr>
         </thead>
         <tbody>
@@ -19,6 +20,7 @@
         <tr>
             <td class="text-center"><a href="@routes.MainController.listVersions(template.commName)">@template.commName</a></td>
             <td class="text-center">@template.commType</td>
+            <td class="text-center">@template.latestVersion</td>
             <td class="text-center"><a href="@commPerformanceLink(template.commName, commPerformanceUrl)" class="btn btn-primary"><span class="glyphicon glyphicon-tasks"></span></a></td>
             <td class="text-center"><a href="@routes.MainController.publishExistingTemplateGet(template.commName)" class="btn btn-primary">
                 Publish new version


### PR DESCRIPTION
<img width="1173" alt="screen shot 2017-03-13 at 18 19 15" src="https://cloud.githubusercontent.com/assets/106760/23869084/bb38e526-0819-11e7-9bfa-2cf55fe46637.png">

Looks like it got lost in #19 